### PR TITLE
Changed the np.int(samps/2) into int(samps/2) for numpy latest compat…

### DIFF
--- a/splitwavepy/core/window.py
+++ b/splitwavepy/core/window.py
@@ -37,7 +37,7 @@ class Window:
         if samps%2 != 1:
             raise Exception('samps must be odd to have definite centre')
         else:
-            centre = np.int(samps/2)
+            centre = int(samps/2)
             return centre + self.offset - hw
 
     def end(self,samps):


### PR DESCRIPTION
Changed the np.int(samps/2) into int(samps/2) for numpy latest compatibility with int for the Attribute Error given below.

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
[<ipython-input-9-dfa0f44024b7>](https://localhost:8080/#) in <cell line: 8>()
      6 sample_interval = st[0].stats.delta
      7 realdata = sw.Pair(north, east, delta=sample_interval)
----> 8 realdata.plot()

4 frames
[/usr/local/lib/python3.10/dist-packages/splitwavepy/core/pair.py](https://localhost:8080/#) in plot(self, **kwargs)
    272         # trace
    273         ax0 = plt.subplot(gs[0])
--> 274         self._ptr( ax0, **kwargs)
    275 
    276         # particle  motion

[/usr/local/lib/python3.10/dist-packages/splitwavepy/core/pair.py](https://localhost:8080/#) in _ptr(self, ax, **kwargs)
    323         # plot window markers
    324         if self.window.width < self._nsamps():
--> 325             w1 = ax.axvline(self.wbeg(),linewidth=1,color='k')
    326             w2 = ax.axvline(self.wend(),linewidth=1,color='k')
    327 

[/usr/local/lib/python3.10/dist-packages/splitwavepy/core/data.py](https://localhost:8080/#) in wbeg(self)
    100         Window start time.
    101         """
--> 102         sbeg = self.window.start(self._nsamps())
    103         return sbeg * self.delta
    104 

[/usr/local/lib/python3.10/dist-packages/splitwavepy/core/window.py](https://localhost:8080/#) in start(self, samps)
     38             raise Exception('samps must be odd to have definite centre')
     39         else:
---> 40             centre = np.int(samps/2)
     41             return centre + self.offset - hw
     42 

[/usr/local/lib/python3.10/dist-packages/numpy/__init__.py](https://localhost:8080/#) in __getattr__(attr)
    317 
    318         if attr in __former_attrs__:
--> 319             raise AttributeError(__former_attrs__[attr])
    320 
    321         if attr == 'testing':

AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations 

